### PR TITLE
LiveXYZ.php - Getting rid of strtolower()

### DIFF
--- a/src/LiveXYZ/LiveXYZ.php
+++ b/src/LiveXYZ/LiveXYZ.php
@@ -61,7 +61,7 @@ class LiveXYZ extends PluginBase implements Listener{
 	}
 	
 	public function onCommand(CommandSender $sender, Command $command, $aliasUsed = "", array $args){
-		if(strtolower($command->getName()) === "xyz"){
+		if($command->getName() === "xyz"){
 			if(!$sender instanceof Player){
 				$sender->sendMessage(TextFormat::RED . "You can't use this command in the terminal");
 				return true;


### PR DESCRIPTION
Very well written but there is something that isn't needed.

$command->getName() returns the command name based on the plugin.yml,  not the player input.
This means strtolower($command->getName()) is useless if the selected command is already lower-case in your plugin.yml.
